### PR TITLE
Vista de error al entrar desde mobile a la cartelera

### DIFF
--- a/src/components/ScreenClient/components/ScreenClient.tsx
+++ b/src/components/ScreenClient/components/ScreenClient.tsx
@@ -4,17 +4,29 @@ import { useEffect } from 'react';
 import { useScreen } from '../store/useScreen';
 import Loader from '../styled-components/Loader';
 import { useConnectionMessage } from '../store/useConnectionMessage';
+import { useState } from 'react';
 
 function ScreenClient({ screenId }: { screenId: number }) {
   const { socketConnection } = useConnectionSocket(screenId);
+  const [isMobile, setIsMobile] = useState(false);
   const setScreenId = useScreen((state) => state.setScreenId);
   const typeScreen = useConnectionMessage((state) => state.connectionMessage);
 
   useEffect(() => {
     setScreenId(screenId);
+    setIsMobile(/Mobi|Android/i.test(navigator.userAgent));
+    console.log(isMobile);
   }, [screenId]);
 
-  return socketConnection && typeScreen.sector.id ? <Screen /> : <Loader />;
+  return isMobile ? (
+    <div className="text-center h-screen w-screen bg-green-700 text-white text-2xl font-bold flex items-center justify-center">
+      No se puede acceder a la cartelera desde un celular.
+    </div>
+  ) : socketConnection && typeScreen.sector.id ? (
+    <Screen />
+  ) : (
+    <Loader />
+  );
 }
 
 export default ScreenClient;


### PR DESCRIPTION
# Que se hizo?
> [Tarea en trello](https://trello.com/c/PCXv3oyG/158-vista-de-error-al-entrar-desde-mobile-a-la-cartelera)
> Se creo una validación cuando se entra en la cartelera para verificar si se entro desde un dispositivo móvil.

# Como se hizo?
> Cuando se inicia la aplicación se verifica mediante un useEffect y un estado isMobile, se setea el estado con una comprobación de redex, si esta comprobacion da verdadero, se setea el estado para que aparezca una pantalla diciendo que no se puede acceder desde un celular.

# Como lo puedo probar?
> 1. Abrís la cartelera
> 2. Abrís las herramientas de desarrollo (F12)
> 3. Se toca el botón marcado con verde.
<img width="380" alt="Screenshot 2023-11-01 000001" src="https://github.com/DesApp-2023c3-Grupo-3/BulletinBoardClient/assets/85763941/60adee98-9d3f-45f4-acb1-54f614a21aec">

# Esta listo para mergear?: SI