### PR TITLE
El boton del modal no aparece si el label es undefined

### DIFF
--- a/src/components/AdminWeb/components/Modal.tsx
+++ b/src/components/AdminWeb/components/Modal.tsx
@@ -9,13 +9,17 @@ interface ModalProps {
   closeModal: () => void;
   openModal: () => void;
   children: React.ReactElement;
-  label: string;
+  label?: string;
 }
 
 function Modal({ isOpen, closeModal, openModal, children, label }: ModalProps) {
   return (
     <>
-      <Button onClick={openModal} active={true} label={label} type={0} />
+      {label ? (
+        <Button onClick={openModal} active={true} label={label} type={0} />
+      ) : (
+        ''
+      )}
       <Transition appear show={isOpen} as={Fragment}>
         <Dialog as="div" className="" onClose={closeModal}>
           <Transition.Child


### PR DESCRIPTION
# Que se hizo?
> El prop label del modal puede ser indefinido, si lo es el boton no aparece en pantalla

# Como se hizo?
> Se agrega la opcion que sea undefined el label, si lo es no muestra el boton

# Como lo puedo probar?
> Si le pones un label al modal es muestra el boton, si se lo sacas no se muestra

# Esta listo para mergear?: SI