### PR TITLE
Deseleccionar las pantallas al ser configuradas

### DIFF
--- a/src/components/AdminWeb/Pages/Pantallas/components/ScreenConfig/ScreenConfig.tsx
+++ b/src/components/AdminWeb/Pages/Pantallas/components/ScreenConfig/ScreenConfig.tsx
@@ -4,6 +4,7 @@ import ButtonDisabled from '../Button/ButtonDisabled';
 import { useConfig } from '../../hooks/useConfig';
 import { useCard } from '../../hooks/useCards';
 import Swal from 'sweetalert2';
+import { useScreenFilters } from '../../store/useScreenFilters';
 
 const Toast = Swal.mixin({
   toast: true,
@@ -19,9 +20,13 @@ function ScreenConfig({ closeModal }: { closeModal: () => void }) {
       advertisingIntervalTime: 15,
       courseIntervalTime: 15,
     });
+  const deselectAllTheScreens = useScreenFilters(
+    (state) => state.deselectAllTheScreens,
+  );
   const { cards, selectCard, cardSelected, isAnyCardSelected } = useCard();
 
   const handleClick = () => {
+    deselectAllTheScreens();
     closeModal();
     Toast.fire({
       icon: 'success',


### PR DESCRIPTION
# Que se hizo?
> Ahora cuando configuras las pantallas, se deseleccionan todas las pantallas de la galeria.

# Como se hizo?
> Se utilizo una funcion llamada deselectAllScreens, la cual deselecciona todas las pantallas.

# Como lo puedo probar?
> 1. Vas a a la sección de pantallas
> 2. Seleccionas alguna pantalla
> 3. Tocas configurar
> 4. Configuras la o las pantallas y le das a aplicar

# Esta listo para mergear?: SI