### PR TITLE
bloqueo de "download template"

### DIFF
--- a/src/components/AdminWeb/Pages/Comisiones/components/Form/FormCommission.tsx
+++ b/src/components/AdminWeb/Pages/Comisiones/components/Form/FormCommission.tsx
@@ -252,12 +252,21 @@ function FormCommission({
         </div>
       </form>
       <div className="flex justify-between mx-6 mt-6">
-        <Button
-          onClick={downloadTemplate}
-          active={hasDocument}
-          type={2}
-          label={'DESCARGAR TEMPLATE'}
-        />
+        {selectedSector.length !== 0 ? (
+          <Button
+            onClick={downloadTemplate}
+            active={hasDocument}
+            type={2}
+            label={'DESCARGAR TEMPLATE'}
+          />
+        ) : (
+          <Button
+            onClick={() => {}}
+            active={true}
+            type={5}
+            label={'DESCARGAR TEMPLATE'}
+          />
+        )}
         {loadingButton ? (
           <Loader
             type={2}


### PR DESCRIPTION
# Qué se hizo?
> Se reintegró el bloqueo del botón "download template" del modal de comisiones cuando no hay un sector seleccionado.
# Cómo se hizo?
> Se agregó nuevamente un condicional que detecte si se seleccionó un sector, para mostrar un botón desactivado si no lo hay.
# Cómo lo puedo probar?
> En el modal de comisiones de administrador, presionar el botón "download template" antes y después de establecer un sector.
# Está listo para mergear? SI