### PR TITLE
fixes de autorizacion por token

### DIFF
--- a/src/components/AdminWeb/Pages/Avisos/Avisos.tsx
+++ b/src/components/AdminWeb/Pages/Avisos/Avisos.tsx
@@ -93,11 +93,7 @@ function Avisos() {
     [
       '',
       (advertising: Advertising) => {
-        try {
-          return userDiv(advertising.user.role.name.charAt(0))
-        } catch {
-          return userDiv('R')
-        }
+        return userDiv(advertising.user.role.name.charAt(0));
       },
     ],
     [
@@ -109,13 +105,13 @@ function Avisos() {
     [
       'Sector/es',
       (advertising: Advertising) => {
-        return sectores(advertising)
+        return sectores(advertising);
       },
     ],
     [
       'Días',
       (advertising: Advertising) => {
-        return schedule(advertising)
+        return schedule(advertising);
       },
     ],
     [

--- a/src/components/AdminWeb/Pages/Avisos/Avisos.tsx
+++ b/src/components/AdminWeb/Pages/Avisos/Avisos.tsx
@@ -109,22 +109,19 @@ function Avisos() {
     [
       'Sector/es',
       (advertising: Advertising) => {
-        try {return sectores(advertising)}
-        catch {return 'sin definir'}
+        return sectores(advertising)
       },
     ],
     [
       'Días',
       (advertising: Advertising) => {
-        try {return schedule(advertising)}
-        catch {return 'sin definir'}
+        return schedule(advertising)
       },
     ],
     [
       'Programación',
       (advertising: Advertising) => {
-        try {return starthour(advertising) + '-' + endhour(advertising);}
-        catch {return 'sin definir'}
+        return starthour(advertising) + '-' + endhour(advertising);
       },
     ],
     [

--- a/src/components/AdminWeb/Pages/Avisos/Avisos.tsx
+++ b/src/components/AdminWeb/Pages/Avisos/Avisos.tsx
@@ -93,7 +93,11 @@ function Avisos() {
     [
       '',
       (advertising: Advertising) => {
-        return userDiv(advertising.user.role.name.charAt(0));
+        try {
+          return userDiv(advertising.user.role.name.charAt(0))
+        } catch {
+          return userDiv('R')
+        }
       },
     ],
     [
@@ -105,19 +109,22 @@ function Avisos() {
     [
       'Sector/es',
       (advertising: Advertising) => {
-        return sectores(advertising);
+        try {return sectores(advertising)}
+        catch {return 'sin definir'}
       },
     ],
     [
       'Días',
       (advertising: Advertising) => {
-        return schedule(advertising);
+        try {return schedule(advertising)}
+        catch {return 'sin definir'}
       },
     ],
     [
       'Programación',
       (advertising: Advertising) => {
-        return starthour(advertising) + '-' + endhour(advertising);
+        try {return starthour(advertising) + '-' + endhour(advertising);}
+        catch {return 'sin definir'}
       },
     ],
     [

--- a/src/components/AdminWeb/Pages/Avisos/components/Form/ImageTextVideo/ImageUp.tsx
+++ b/src/components/AdminWeb/Pages/Avisos/components/Form/ImageTextVideo/ImageUp.tsx
@@ -25,7 +25,7 @@ function ImageUp({ image, setImage }: ImageUpProps) {
       imageAPI
         .create(formData)
         .then((r) => {
-          urlImg = `${ROUTES_RELATIVE.image.image}/${r.data.id}/view`;
+          urlImg = `${ROUTES_RELATIVE.image.image}/${r?.data.id}/view`;
           setImage(urlImg);
           setLoading(false);
         })

--- a/src/services/image.ts
+++ b/src/services/image.ts
@@ -1,18 +1,35 @@
 import axios from "axios";
 import { ROUTES_RELATIVE } from "../routes/route.relatives";
-import { getTokens, handleCall, getHeaders } from "./validationMiddleware";
+import { getTokens, setTokens, redirectToLogin, handleCall, getHeaders } from "./validationMiddleware";
+import { tokenApi } from "./auth";
 
 export const imageAPI = {
     viewId: function(id : number) {
         return handleCall(axios.get, [`${ROUTES_RELATIVE.image}/${id}/view`])
     },
-    create: function(image : any) {
-        return axios.post(ROUTES_RELATIVE.image.image, image, {
-            headers: {
-                "Content-Type": 'multipart/form-data',
-                "Authorization": `${getTokens().accessToken}`
-              }
-        })
+    create: async function(image : any) {
+        try {
+            try {
+                return axios.post(ROUTES_RELATIVE.image.image, image, {
+                    headers: {
+                        "Content-Type": 'multipart/form-data',
+                        "Authorization": `Bearer ${getTokens().accessToken}`
+                }
+            })} catch {
+                const { data } = await tokenApi.refresh({ "refreshToken": `${getTokens().refreshToken}` });
+                setTokens(data.accessToken, data.refreshToken);
+                return axios.post(ROUTES_RELATIVE.image.image, image, {
+                    headers: {
+                        "Content-Type": 'multipart/form-data',
+                        "Authorization": `Bearer ${getTokens().accessToken}`
+                    }
+                })
+            }
+        } catch (error) {
+            console.error("Refresh Token Error:", error);
+            redirectToLogin()
+        }
+        
     },
     viewQr: function() {
         return axios.get(ROUTES_RELATIVE.image.planeViewQr, {


### PR DESCRIPTION
# Qué se hizo?
> Se actualizó el chequeo del token a los llamados al servidor que no acceden al handleCall
# Cómo se hizo?
> Se agregó la comprobación que realiza handleCall (uso del refreshToken y redirección al login) tanto a la descarga de template de comisiones como a la subida de imágenes de avisos
# Cómo lo puedo probar?
> En Administrador:
> - Ir al modal de comisiones, seleccionar un sector y clickear el botón "descargar template"
> - Ir al modal de avisos y subir una imagen en el input de explorador de archivos
# Está listo para mergear? SI