### PR TITLE
Fix del filtro seleccionar todas las pantallas

### DIFF
--- a/src/components/AdminWeb/Pages/Pantallas/components/ScreenConfig/components/ButtonSection.tsx
+++ b/src/components/AdminWeb/Pages/Pantallas/components/ScreenConfig/components/ButtonSection.tsx
@@ -51,7 +51,9 @@ export default function ButtonSection({
   const updateScreens = () => {
     selectedScreens.forEach((screen) => {
       screen.typeScreen = String(cardSelected?.id);
-      screen.sector = selectedSector[0];
+      if (selectedScreens.length === 1) {
+        screen.sector = selectedSector[0];
+      }
     });
 
     const mappedScreens = selectedScreens.map((screen) => {
@@ -92,7 +94,10 @@ export default function ButtonSection({
     const newScreens = selectedScreens.map((screen) => {
       screen.advertisingIntervalTime = config.advertisingIntervalTime;
       screen.courseIntervalTime = config.courseIntervalTime;
-      screen.sectorTitle = selectedSector[0].name;
+
+      if (selectedScreens.length === 1) {
+        screen.sectorTitle = selectedSector[0].name;
+      }
 
       return screen;
     });

--- a/src/components/AdminWeb/Pages/Pantallas/components/ScreenHeader/components/SelectAllFilter.tsx
+++ b/src/components/AdminWeb/Pages/Pantallas/components/ScreenHeader/components/SelectAllFilter.tsx
@@ -3,9 +3,10 @@ import { useScreenFilters } from '../../../store/useScreenFilters';
 import { useFilters } from '../../../store/useFilters';
 
 function SelectAllFilter() {
-  const [isSelectedAll, setIsSelectedAll] = useFilters((state) => [
+  const [isSelectedAll, setIsSelectedAll, sector] = useFilters((state) => [
     state.isSelectedAll,
     state.setIsSelectedAll,
+    state.sector,
   ]);
   const [screens, deselectAllTheScreens, selectAllTheScreens] =
     useScreenFilters((state) => [
@@ -14,15 +15,19 @@ function SelectAllFilter() {
       state.selectAllTheScreens,
     ]);
 
+  const filteredScreens = screens.filter(
+    (screen) => screen.sectorTitle === sector || sector === 'Todos',
+  );
+
   useEffect(() => {
-    setIsSelectedAll(screens.every((screen) => screen.isSelected));
+    setIsSelectedAll(filteredScreens.every((screen) => screen.isSelected));
   }, [screens]);
 
   const handleChange = () => {
     if (isSelectedAll) {
       deselectAllTheScreens();
     } else {
-      selectAllTheScreens();
+      selectAllTheScreens(filteredScreens);
     }
   };
 

--- a/src/components/AdminWeb/Pages/Pantallas/store/useScreenFilters.ts
+++ b/src/components/AdminWeb/Pages/Pantallas/store/useScreenFilters.ts
@@ -2,7 +2,7 @@ import { create } from "zustand";
 
 export interface Screen {
     id: number
-    screenTitle: string, 
+    screenTitle: string,
     sectorTitle: string,
     typeScreen: string,
     subscription: string,
@@ -10,32 +10,34 @@ export interface Screen {
     advertisingIntervalTime: number
     courseIntervalTime: number
     sector: {
-        id:number,
-        topic:string,
-        name:string
+        id: number,
+        topic: string,
+        name: string
     }
 }
 
 interface StoreScreen {
     screens: Screen[]
-    selectAllTheScreens: () => void
+    selectAllTheScreens: (screens: Screen[]) => void
     deselectAllTheScreens: () => void
-    selectScreen: (id:number) => void
-    addScreens: (screens:Screen[]) => void
+    selectScreen: (id: number) => void
+    addScreens: (screens: Screen[]) => void
 }
 
 export const useScreenFilters = create<StoreScreen>()((set, get) => ({
     screens: [],
 
-    selectAllTheScreens: () => {
-        const newScreens = get().screens.map(screen => {
-            screen.isSelected = true
+    selectAllTheScreens: (selectedScreens: Screen[]) => {
+        const newSelectedScreens = get().screens.map(screen => {
+            if (selectedScreens.some(selectedScreen => selectedScreen.id === screen.id)) {
+                screen.isSelected = true
+            }
             return screen
         })
         set({
-            screens: newScreens
+            screens: newSelectedScreens
         })
-    }, 
+    },
 
     deselectAllTheScreens: () => {
         const newScreens = get().screens.map(screen => {
@@ -47,24 +49,24 @@ export const useScreenFilters = create<StoreScreen>()((set, get) => ({
         })
     },
 
-    
-    selectScreen : (id:number) => {
+
+    selectScreen: (id: number) => {
         const newScreens = get().screens.map(screen => {
             const screenAux = screen
-            if(screenAux.id === id) {
-                screenAux.isSelected = !screenAux.isSelected 
+            if (screenAux.id === id) {
+                screenAux.isSelected = !screenAux.isSelected
             }
-            return screenAux     
+            return screenAux
         })
         set({
             screens: newScreens
         })
     },
 
-    addScreens: (screens:Screen[]) => {
+    addScreens: (screens: Screen[]) => {
         set({
             screens
         })
     }
-    
+
 }))


### PR DESCRIPTION
Fix 1: Cuando se tocaba el boton de seleccionar todas las pantallas, se seleccionaba las pantallas incluso filtradas. Ahora se seleccionan solo las que aparecen en pantalla.

Fix 2: Cuando se actualizaba más de una pantalla, se actualizaban todos los sectores de las pantallas en uno solo, por ejemplo, si una pantalla tenía como sector Malvinas Argentinas y la otra Gratuidad Universitaria, al actualizarlas, las dos pantallas se ponían en Malvinas Argentinas. Ahora esto deja de ocurrir, y cada pantalla queda con el sector que ya tenía.